### PR TITLE
Auto-Cache: adding support for automatic key expiration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: scala
 
 scala:
-  - 2.12.6
+  - 2.12.7
   - 2.11.12
 
 before_cache:

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ lazy val commonSettings = Seq(
   scalacOptions += "-Yrangepos",
 
   addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.8" cross CrossVersion.binary),
-  addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0-M2"),
+  addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.2.4"),
 
   libraryDependencies ++= Seq(
     "org.typelevel"               %% "cats-core"                  % catsV,

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val core = project.in(file("."))
     )
 
 val catsV = "1.4.0"
-val catsEffectV = "1.0.0"
+val catsEffectV = "1.1.0-M1"
 
 val specs2V = "4.3.5"
 val disciplineV = "0.10.0"
@@ -20,13 +20,13 @@ lazy val contributors = Seq(
 lazy val commonSettings = Seq(
   organization := "io.chrisdavenport",
 
-  scalaVersion := "2.12.6",
+  scalaVersion := "2.12.7",
   crossScalaVersions := Seq(scalaVersion.value, "2.11.12"),
 
   scalacOptions += "-Yrangepos",
 
   addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.8" cross CrossVersion.binary),
-  addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.2.4"),
+  addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0-M2"),
 
   libraryDependencies ++= Seq(
     "org.typelevel"               %% "cats-core"                  % catsV,

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val core = project.in(file("."))
     )
 
 val catsV = "1.4.0"
-val catsEffectV = "1.1.0-M1"
+val catsEffectV = "1.0.0"
 
 val specs2V = "4.3.5"
 val disciplineV = "0.10.0"

--- a/src/main/scala/io/chrisdavenport/mules/Cache.scala
+++ b/src/main/scala/io/chrisdavenport/mules/Cache.scala
@@ -84,8 +84,8 @@ class Cache[F[_], K, V] private[Cache] (
 
 object Cache {
   // Value of Time In Nanoseconds
-  case class TimeSpec private (
-    nanos: Long
+  class TimeSpec private (
+    val nanos: Long
   ) extends AnyVal
   object TimeSpec {
 

--- a/src/main/scala/io/chrisdavenport/mules/Cache.scala
+++ b/src/main/scala/io/chrisdavenport/mules/Cache.scala
@@ -127,7 +127,7 @@ object Cache {
         checkOnExpirationsEvery: TimeSpec
    ): F[Cache[F, K, V]] = {
       def runExpiration(cache: Cache[F, K, V]): F[Unit] =
-        Timer[F].sleep(checkOnExpirationsEvery.toDuration) >> purgeExpired(cache) >> runExpiration(cache)
+        implicitly[Timer[F]].sleep(checkOnExpirationsEvery.toDuration) >> purgeExpired(cache) >> runExpiration(cache)
 
       Ref.of[F, Map[K, CacheItem[V]]](Map.empty[K, CacheItem[V]])
         .map(ref => new Cache[F, K, V](ref, Some(expiresIn)))

--- a/src/main/scala/io/chrisdavenport/mules/Cache.scala
+++ b/src/main/scala/io/chrisdavenport/mules/Cache.scala
@@ -126,12 +126,12 @@ object Cache {
         expiresIn: TimeSpec,
         checkOnExpirationsEvery: TimeSpec
    ): F[Cache[F, K, V]] = {
-     def runExpiration(cache: Cache[F, K, V]): F[Unit] =
-       Timer[F].sleep(checkOnExpirationsEvery.toDuration) >> purgeExpired(cache) >> runExpiration(cache)
+      def runExpiration(cache: Cache[F, K, V]): F[Unit] =
+        Timer[F].sleep(checkOnExpirationsEvery.toDuration) >> purgeExpired(cache) >> runExpiration(cache)
 
       Ref.of[F, Map[K, CacheItem[V]]](Map.empty[K, CacheItem[V]])
-       .map(ref => new Cache[F, K, V](ref, Some(expiresIn)))
-       .flatTap(runExpiration(_).start.void)
+        .map(ref => new Cache[F, K, V](ref, Some(expiresIn)))
+        .flatTap(runExpiration(_).start.void)
      }
 
   /**

--- a/src/test/scala/io/chrisdavenport/mules/AutoCacheSpec.scala
+++ b/src/test/scala/io/chrisdavenport/mules/AutoCacheSpec.scala
@@ -66,9 +66,9 @@ object WithTestContext {
 
   def apply[A](f: TestContext => ContextShift[IO] => Timer[IO] => Clock[IO] => A): A = {
     val ctx = TestContext()
-    implicit val cs: ContextShift[IO] = IO.contextShift(ctx)
-    implicit val timer: Timer[IO] = ctx.timer[IO]
-    implicit val clock: Clock[IO] = timer.clock
+    val cs: ContextShift[IO] = IO.contextShift(ctx)
+    val timer: Timer[IO] = ctx.timer[IO]
+    val clock: Clock[IO] = timer.clock
     f(ctx)(cs)(timer)(clock)
   }
 


### PR DESCRIPTION
This is a port of the code I released under MIT license [here](https://github.com/paidy/talks/blob/master/2018-10-30/scalaio-demo/src/main/scala/com/paidy/demo/cache/Cache.scala).

~Still haven't managed to get the tests passing with this new implementation but I'm working on it~.  So far it seems to be working fine re-using the existing `purgeExpired` method. Here's an example:

```scala
import cats.effect.{ExitCode, IO, IOApp}
import cats.implicits._

import scala.concurrent.duration._
import scala.util.Random

object Demo extends IOApp {

  val expiresIn  = Cache.TimeSpec.fromDuration(5.seconds)
  val checkEvery = Cache.TimeSpec.fromDuration(1.millis)

  def putStrLn[A](a: A): IO[Unit] = IO(println(a))

  val program: IO[Unit] =
    (expiresIn, checkEvery).tupled.fold(putStrLn("Invalid cache params")) { case (ex, ce) =>
      Cache.createAutoCache[IO, Int, String](ex, ce).flatMap { cache =>
        val randomKeyValue: IO[(Int, String)] =
          IO(Random.nextInt(100) -> Random.nextString(5))

        def loop: IO[Unit] = {
          IO.sleep(1.second) >> randomKeyValue.flatMap { case (k, v) => cache.insert(k, v) } >>
            cache.keys.flatMap(putStrLn) >> loop
        }

        loop
      }
    }

  override def run(args: List[String]): IO[ExitCode] =
    program.as(ExitCode.Success)

}
```

A possible output as expected:

```
List(61)
List(61, 67)
List(61, 67, 31)
List(61, 67, 31, 68)
List(61, 67, 31, 47, 68)
List(74, 67, 31, 47, 68)
List(74, 28, 31, 47, 68)
List(88, 74, 28, 47, 68)
List(88, 74, 28, 18, 47)
List(88, 74, 28, 86, 18)
List(88, 28, 86, 18, 19)
List(88, 64, 86, 18, 19)
List(10, 64, 86, 18, 19)
List(10, 37, 64, 86, 19)
List(10, 37, 64, 91, 19)
List(10, 37, 92, 64, 91)
List(10, 37, 92, 91, 94)
List(37, 89, 92, 91, 94)
```

Probably worth adding this example in a different module or at least in the docs, happy to add that :)

Also upgraded a few dependencies.