### PR TITLE
Use MapRef for Generic Approaches

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,8 +37,10 @@ lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
     "org.typelevel"               %% "cats-core"                  % catsV,
     "org.typelevel"               %% "cats-effect"                % catsEffectV,
+    "io.chrisdavenport"           %% "mapref"                     % "0.0.2",
 
     "org.typelevel"               %% "cats-effect-laws"           % catsEffectV   % Test,
+    "com.codecommit"              %% "cats-effect-testing-specs2" % "0.3.0"       % Test,
     "org.specs2"                  %% "specs2-core"                % specs2V       % Test,
     "org.specs2"                  %% "specs2-scalacheck"          % specs2V       % Test,
     "org.typelevel"               %% "discipline-specs2"          % disciplineSpecs2V % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
     "org.typelevel"               %% "cats-core"                  % catsV,
     "org.typelevel"               %% "cats-effect"                % catsEffectV,
-    "io.chrisdavenport"           %% "mapref"                     % "0.0.2",
+    "io.chrisdavenport"           %% "mapref"                     % "0.0.3",
 
     "org.typelevel"               %% "cats-effect-laws"           % catsEffectV   % Test,
     "com.codecommit"              %% "cats-effect-testing-specs2" % "0.3.0"       % Test,

--- a/modules/core/src/main/scala/io/chrisdavenport/mules/Cache.scala
+++ b/modules/core/src/main/scala/io/chrisdavenport/mules/Cache.scala
@@ -6,6 +6,7 @@ trait Lookup[F[_], K, V]{
 
 trait Insert[F[_], K, V]{
   def insert(k: K, v: V): F[Unit]
+  def insertWithTimeout(optionTimeout: Option[TimeSpec])(k: K, v: V): F[Unit]
 }
 
 trait Delete[F[_], K]{

--- a/modules/core/src/main/scala/io/chrisdavenport/mules/MemoryCache.scala
+++ b/modules/core/src/main/scala/io/chrisdavenport/mules/MemoryCache.scala
@@ -1,9 +1,7 @@
 package io.chrisdavenport.mules
 
 import cats._
-// import cats.data._
 import cats.effect._
-// For Cats-effect 1.0
 import cats.effect.concurrent.Ref
 import cats.effect.syntax.concurrent._
 import cats.implicits._
@@ -389,11 +387,9 @@ object MemoryCache {
         m => {
           val timeSpec = TimeSpec.unsafeFromNanos(now)
           val l = scala.collection.mutable.ListBuffer.empty[K]
-          m.keys.foreach{ k => 
-            m.get(k).foreach{item => 
-              if (isExpired(timeSpec, item)) {
-                l.+=(k)
-              }
+          m.foreach{ case (k, item) => 
+            if (isExpired(timeSpec, item)) {
+              l.+=(k)
             }
           }
           val remove = l.result

--- a/modules/core/src/main/scala/io/chrisdavenport/mules/MemoryCache.scala
+++ b/modules/core/src/main/scala/io/chrisdavenport/mules/MemoryCache.scala
@@ -10,8 +10,16 @@ import cats.implicits._
 import scala.concurrent.duration._
 import scala.collection.immutable.Map
 
+import io.chrisdavenport.mapref.MapRef
+import io.chrisdavenport.mapref.implicits._
+
+import java.util.concurrent.ConcurrentHashMap
+
 final class MemoryCache[F[_], K, V] private[MemoryCache] (
-  private val ref: Ref[F, Map[K, MemoryCache.MemoryCacheItem[V]]],
+  // private val ref: Ref[F, Map[K, MemoryCache.MemoryCacheItem[V]]],
+  private val mapRef: MapRef[F, K, Option[MemoryCache.MemoryCacheItem[V]]],
+  val keys: F[Chain[K]], // Passed In From External Defined State
+  private val purgeExpiredEntries : Long => F[Chain[K]],
   val defaultExpiration: Option[TimeSpec],
   private val onInsert: (K, V) => F[Unit],
   private val onCacheHit: (K, V) => F[Unit],
@@ -24,7 +32,7 @@ final class MemoryCache[F[_], K, V] private[MemoryCache] (
    * Delete an item from the cache. Won't do anything if the item is not present.
    **/
   def delete(k: K): F[Unit] = 
-    ref.update(m => m - (k)).void <* onDelete(k)
+    mapRef.unsetKey(k) >> onDelete(k)
 
   /**
    * Insert an item in the cache, using the default expiration value of the cache.
@@ -43,24 +51,19 @@ final class MemoryCache[F[_], K, V] private[MemoryCache] (
     for {
       now <- C.monotonic(NANOSECONDS)
       timeout = optionTimeout.map(ts => TimeSpec.unsafeFromNanos(now + ts.nanos))
-      _ <- ref.update(m => m + (k -> MemoryCacheItem[V](v, timeout)))
+      _ <- mapRef.setKeyValue(k, MemoryCacheItem[V](v, timeout))
       _ <- onInsert(k, v)
     } yield ()
   }
     
 
-  private def isExpired[A](checkAgainst: TimeSpec, cacheItem: MemoryCacheItem[A]): Boolean = {
-    cacheItem.itemExpiration.fold(false){
-      case e if e.nanos < checkAgainst.nanos => true
-      case _ => false
-    }
-  }
+  
 
   /**
    * Return all keys present in the cache, including expired items.
    **/
-  def keys: F[List[K]] = 
-    ref.get.map(_.keys.toList)
+  // def keys: F[Chains[K]] = key
+    // ref.get.map(_.keys.toList)
 
   /**
    * Lookup an item with the given key, and delete it if it is expired.
@@ -86,13 +89,12 @@ final class MemoryCache[F[_], K, V] private[MemoryCache] (
   private def lookupItemT(del: Boolean, k: K, t: TimeSpec): F[Option[MemoryCacheItem[V]]] = {
     for {
       (i, gotDeleted) <- {
-        ref.modify{ map => 
-          val value = map.get(k)
-          val exp = value.map(isExpired(t, _)).getOrElse(false)
+        mapRef(k).modify{ value =>
+          val exp = value.map(MemoryCache.isExpired(t, _)).getOrElse(false)
           val willRemove = del && exp
-          val newMapOpt = Alternative[Option].guard(willRemove).as(map - (k))
+          val newValOpt = Alternative[Option].guard(!willRemove)
           val nonExpiredValue = Alternative[Option].guard(!exp) *> value
-          val out = (newMapOpt.getOrElse(map), (nonExpiredValue, willRemove))
+          val out = (newValOpt *> value, (nonExpiredValue, willRemove))
           out
         }
       }
@@ -124,7 +126,9 @@ final class MemoryCache[F[_], K, V] private[MemoryCache] (
    **/
   def setDefaultExpiration(defaultExpiration: Option[TimeSpec]): MemoryCache[F, K, V] = 
     new MemoryCache[F, K, V](
-      ref,
+      mapRef,
+      keys,
+      purgeExpiredEntries,
       defaultExpiration,
       onInsert,
       onCacheHit,
@@ -137,7 +141,9 @@ final class MemoryCache[F[_], K, V] private[MemoryCache] (
    */
   def setOnCacheHit(onCacheHitNew: (K, V) => F[Unit]): MemoryCache[F, K, V] = 
     new MemoryCache[F, K, V](
-      ref,
+      mapRef,
+      keys,
+      purgeExpiredEntries,
       defaultExpiration,
       onInsert,
       onCacheHitNew,
@@ -150,7 +156,9 @@ final class MemoryCache[F[_], K, V] private[MemoryCache] (
    */
   def setOnCacheMiss(onCacheMissNew: K => F[Unit]): MemoryCache[F, K, V] = 
     new MemoryCache[F, K, V](
-      ref,
+      mapRef,
+      keys,
+      purgeExpiredEntries,
       defaultExpiration,
       onInsert,
       onCacheHit,
@@ -162,7 +170,9 @@ final class MemoryCache[F[_], K, V] private[MemoryCache] (
    */
   def setOnDelete(onDeleteNew: K => F[Unit]): MemoryCache[F, K, V] = 
     new MemoryCache[F, K, V](
-      ref,
+      mapRef,
+      keys,
+      purgeExpiredEntries,
       defaultExpiration,
       onInsert,
       onCacheHit,
@@ -175,7 +185,9 @@ final class MemoryCache[F[_], K, V] private[MemoryCache] (
    */
   def setOnInsert(onInsertNew: (K, V) => F[Unit]): MemoryCache[F, K, V] = 
     new MemoryCache[F, K, V](
-      ref,
+      mapRef,
+      keys,
+      purgeExpiredEntries,
       defaultExpiration,
       onInsertNew,
       onCacheHit,
@@ -187,16 +199,10 @@ final class MemoryCache[F[_], K, V] private[MemoryCache] (
   /**
    * Return the size of the cache, including expired items.
    **/
-  def size: F[Int] = 
-    ref.get.map(_.size)
+  def size: F[Long] = 
+    keys.map(_.size)
 
-  private def purgeKeyIfExpired(m: Map[K, MemoryCacheItem[V]], k: K, checkAgainst: TimeSpec): (Map[K, MemoryCacheItem[V]], Option[K]) = 
-    m.get(k)
-      .map(item => 
-        if (isExpired(checkAgainst, item)) ((m - (k)), k.some) 
-        else (m, None)
-      )
-      .getOrElse((m, None))
+
 
 
   /**
@@ -207,15 +213,7 @@ final class MemoryCache[F[_], K, V] private[MemoryCache] (
   def purgeExpired: F[Unit] = {
     for {
       now <- C.monotonic(NANOSECONDS)
-      chain <- ref.modify(
-        m => {
-          m.keys.toList
-            .foldLeft((m, Chain.empty[K])){ case ((m, acc), k) => 
-              val (mOut, maybeDeleted) = purgeKeyIfExpired(m, k, TimeSpec.unsafeFromNanos(now))
-              maybeDeleted.fold((mOut, acc))(kv => (mOut, acc :+ kv))
-            }
-        }
-      )// One Big Transactional Change
+      chain <- purgeExpiredEntries(now)
       _ <- chain.traverse_(onDelete)
     } yield ()
   }
@@ -225,7 +223,9 @@ final class MemoryCache[F[_], K, V] private[MemoryCache] (
    */
   def withOnCacheHit(onCacheHitNew: (K, V) => F[Unit]): MemoryCache[F, K, V] = 
     new MemoryCache[F, K, V](
-      ref,
+      mapRef,
+      keys,
+      purgeExpiredEntries,
       defaultExpiration,
       onInsert,
       {(k, v) => onCacheHit(k, v) >> onCacheHitNew(k, v)},
@@ -238,7 +238,9 @@ final class MemoryCache[F[_], K, V] private[MemoryCache] (
    */
   def withOnCacheMiss(onCacheMissNew: K => F[Unit]): MemoryCache[F, K, V] = 
     new MemoryCache[F, K, V](
-      ref,
+      mapRef,
+      keys,
+      purgeExpiredEntries,
       defaultExpiration,
       onInsert,
       onCacheHit,
@@ -251,7 +253,9 @@ final class MemoryCache[F[_], K, V] private[MemoryCache] (
    */
   def withOnDelete(onDeleteNew: K => F[Unit]): MemoryCache[F, K, V] = 
     new MemoryCache[F, K, V](
-      ref,
+      mapRef,
+      keys,
+      purgeExpiredEntries,
       defaultExpiration,
       onInsert,
       onCacheHit,
@@ -264,7 +268,9 @@ final class MemoryCache[F[_], K, V] private[MemoryCache] (
    */
   def withOnInsert(onInsertNew: (K, V) => F[Unit]): MemoryCache[F, K, V] = 
     new MemoryCache[F, K, V](
-      ref,
+      mapRef,
+      keys,
+      purgeExpiredEntries,
       defaultExpiration,
       {(k, v) => onInsert(k, v) >> onInsertNew(k, v)},
       onCacheHit,
@@ -281,39 +287,25 @@ object MemoryCache {
   )
 
   /**
-   * Creates a new cache with default expiration and automatic key-expiration support.
    *
-   * It fires off a background process that checks for expirations every certain amount of time.
+   * Initiates a background process that checks for expirations every certain amount of time.
    *
-   * @param expiresIn: the expiration time of every key-value in the MemoryCache.
-   * @param checkOnExpirationsEvery: how often the expiration process should check for expired keys.
+   * @param memoryCache: The cache to check and expire automatically.
+   * @param checkOnExpirationsEvery: How often the expiration process should check for expired keys.
    *
-   * @return an `[F[MemoryCache[F, K, V]]` that will create a MemoryCache with key-expiration support when evaluated.
+   * @return an `Resource[F, Unit]` that will keep removing expired entries in the background.
    **/
-  def createAutoMemoryCache[F[_]: Concurrent: Timer, K, V](
-    expiresIn: TimeSpec,
+  def liftToAuto[F[_]: Concurrent: Timer, K, V](
+    memoryCache: MemoryCache[F, K, V],
     checkOnExpirationsEvery: TimeSpec
-  ): Resource[F, MemoryCache[F, K, V]] = {
+  ): Resource[F, Unit] = {
     def runExpiration(cache: MemoryCache[F, K, V]): F[Unit] = {
       val check = TimeSpec.toDuration(checkOnExpirationsEvery)
       Timer[F].sleep(check) >> cache.purgeExpired >> runExpiration(cache)
     }
 
-    Resource(
-      Ref.of[F, Map[K, MemoryCacheItem[V]]](Map.empty[K, MemoryCacheItem[V]])
-        .map(ref => new MemoryCache[F, K, V](
-          ref,
-          Some(expiresIn), 
-          {(_, _) => Sync[F].unit},
-          {(_, _) => Sync[F].unit},
-          {_: K => Sync[F].unit},
-          {_: K => Sync[F].unit}
-        ))
-        .flatMap(cache => 
-          runExpiration(cache).start.map(fiber => (cache, fiber.cancel))
-        )
-      )
-    }
+    Resource.make(runExpiration(memoryCache).start)(_.cancel).void
+  }
 
   /**
     * Create a new cache with a default expiration value for newly added cache items.
@@ -322,12 +314,14 @@ object MemoryCache {
     * 
     * If the specified default expiration value is None, items inserted by insert will never expire.
     **/
-  def createMemoryCache[F[_]: Sync: Clock, K, V](
+  def ofSingleImmutableMap[F[_]: Sync: Clock, K, V](
     defaultExpiration: Option[TimeSpec]
   ): F[MemoryCache[F, K, V]] = 
     Ref.of[F, Map[K, MemoryCacheItem[V]]](Map.empty[K, MemoryCacheItem[V]])
-      .map(new MemoryCache[F, K, V](
-        _, 
+      .map(ref => new MemoryCache[F, K, V](
+        MapRef.fromSingleImmutableMapRef(ref),
+        SingleRef.keys(ref),
+        SingleRef.purgeExpiredEntries(ref)(_),
         defaultExpiration,
         {(_, _) => Sync[F].unit},
         {(_, _) => Sync[F].unit},
@@ -335,19 +329,92 @@ object MemoryCache {
         {_: K => Sync[F].unit}
       ))
 
-  /**
-    * Create a deep copy of the cache.
-    **/ 
-  def copyMemoryCache[F[_]: Sync, K, V](cache: MemoryCache[F, K, V]): F[MemoryCache[F, K, V]] = for {
-    current <- cache.ref.get
-    ref <- Ref.of[F, Map[K, MemoryCacheItem[V]]](current)
-  } yield new MemoryCache[F, K, V](
-    ref,
-    cache.defaultExpiration,
-    cache.onInsert,
-    cache.onCacheHit,
-    cache.onCacheMiss,
-    cache.onDelete
-  )(cache.F, cache.C)
+  def ofConcurrentHashMap[F[_]: Sync: Clock, K, V](
+    defaultExpiration: Option[TimeSpec],
+    initialCapacity: Int = 16,
+    loadFactor: Float = 0.75f,
+    concurrencyLevel: Int = 16,
+  ): F[MemoryCache[F, K, V]] = Sync[F].delay{
+    val chm = new ConcurrentHashMap[K, MemoryCacheItem[V]](initialCapacity, loadFactor, concurrencyLevel)
+    new MemoryCache[F, K, V](
+      MapRef.fromConcurrentHashMap(chm),
+      CHashMap.keys(chm),
+      CHashMap.purgeExpiredEntries(chm)(_),
+      defaultExpiration,
+      {(_, _) => Sync[F].unit},
+      {(_, _) => Sync[F].unit},
+      {_: K => Sync[F].unit},
+      {_: K => Sync[F].unit}
+    )
+  }
 
+
+  private object SingleRef {
+    def keys[F[_]: Functor, K, V](ref: Ref[F, Map[K, V]]): F[Chain[K]] = ref.get.map(m => Chain.fromSeq(m.keys.toSeq))
+
+    def purgeExpiredEntries[F[_], K, V](ref: Ref[F, Map[K, MemoryCacheItem[V]]])(now: Long): F[Chain[K]] = {
+      ref.modify(
+        m => {
+          m.keys.toList
+            .foldLeft((m, Chain.empty[K])){ case ((m, acc), k) => 
+              val (mOut, maybeDeleted) = purgeKeyIfExpired(m, k, TimeSpec.unsafeFromNanos(now))
+              maybeDeleted.fold((mOut, acc))(kv => (mOut, acc :+ kv))
+            }
+        }
+      )
+    }
+    private def purgeKeyIfExpired[K, V](m: Map[K, MemoryCacheItem[V]], k: K, checkAgainst: TimeSpec): (Map[K, MemoryCacheItem[V]], Option[K]) = 
+      m.get(k)
+        .map(item => 
+          if (isExpired(checkAgainst, item)) ((m - (k)), k.some) 
+          else (m, None)
+        )
+        .getOrElse((m, None))
+  }
+  private object CHashMap {
+    def keys[F[_]: Sync, K, V](chm: ConcurrentHashMap[K, V]): F[Chain[K]] = Sync[F].delay{
+      val k = chm.keys()
+      val i = Iterator.continually((k, k.nextElement()))
+        .takeWhile(_._1.hasMoreElements)
+        .map(_._2)
+        .toSeq
+      Chain.fromSeq(i)
+    }
+
+    def purgeExpiredEntries[F[_]: Sync, K, V](chm: ConcurrentHashMap[K, MemoryCacheItem[V]])(now: Long): F[Chain[K]] = Sync[F].delay{
+      val timeSpec = TimeSpec.unsafeFromNanos(now)
+      val i = {
+          val keys = chm.keys()
+          if (keys == null) Iterator.empty
+          else Iterator.continually((keys, keys.nextElement()))
+        }
+        .takeWhile(_._1.hasMoreElements)
+        .map(_._2)
+        .flatMap{k => 
+          val init = chm.get(k)
+          if (init == null) Iterator.empty
+          else {
+            if (isExpired(timeSpec, init)) {
+              chm.remove(k)
+              Iterator(k)
+            }
+            else Iterator.empty
+          }
+        
+        }.toSeq
+      Chain.fromSeq(i)
+
+    }
+  }
+
+  
+
+
+
+  private def isExpired[A](checkAgainst: TimeSpec, cacheItem: MemoryCacheItem[A]): Boolean = {
+    cacheItem.itemExpiration.fold(false){
+      case e if e.nanos < checkAgainst.nanos => true
+      case _ => false
+    }
+  }
 }

--- a/modules/core/src/main/scala/io/chrisdavenport/mules/MemoryCache.scala
+++ b/modules/core/src/main/scala/io/chrisdavenport/mules/MemoryCache.scala
@@ -224,7 +224,7 @@ final class MemoryCache[F[_], K, V] private[MemoryCache] (
   def purgeExpired: F[Unit] = {
     for {
       now <- C.monotonic(NANOSECONDS)
-      out <- purgeExpiredEntriesDefault(now)
+      out <- purgeExpiredEntries(now)
       _ <-  out.traverse_(onDelete)
     } yield ()
   }

--- a/modules/core/src/test/scala/io/chrisdavenport/mules/AutoMemoryCacheSpec.scala
+++ b/modules/core/src/test/scala/io/chrisdavenport/mules/AutoMemoryCacheSpec.scala
@@ -1,7 +1,7 @@
 package io.chrisdavenport.mules
 
 import cats.effect.laws.util.TestContext
-import cats.effect.{ContextShift, IO, Timer}
+import cats.effect._
 import cats.implicits._
 import org.specs2.mutable.Specification
 
@@ -12,10 +12,11 @@ class AutoMemoryCacheSpec extends Specification {
   val cacheKeyExpiration    = TimeSpec.unsafeFromDuration(12.hours)
   val checkExpirationsEvery = TimeSpec.unsafeFromDuration(10.millis)
 
-  "Auto MemoryCache" should {
+  "Auto MemoryCache.ofSingleImmutableMap" should {
 
     "expire keys" in WithTestContext { ctx => implicit cs => implicit timer =>
-      val spec = MemoryCache.createAutoMemoryCache[IO, Int, String](cacheKeyExpiration, checkExpirationsEvery)
+      val spec = Resource.liftF(MemoryCache.ofSingleImmutableMap[IO, Int, String](cacheKeyExpiration.some))
+        .flatMap(cache => MemoryCache.liftToAuto(cache, checkExpirationsEvery).as(cache))
         .use(cache =>
           for {
             _ <- cache.insert(1, "foo")
@@ -40,7 +41,60 @@ class AutoMemoryCacheSpec extends Specification {
     }
 
     "resets expiration" in WithTestContext { ctx => implicit cs => implicit timer =>
-      val spec = MemoryCache.createAutoMemoryCache[IO, Int, String](cacheKeyExpiration, checkExpirationsEvery).use(cache => 
+      val spec = Resource.liftF(MemoryCache.ofSingleImmutableMap[IO, Int, String](cacheKeyExpiration.some))
+        .flatMap(cache => MemoryCache.liftToAuto(cache, checkExpirationsEvery).as(cache))
+        .use(cache => 
+        for {
+          _ <- cache.insert(1, "foo")
+          _ <- IO(ctx.tick(5.hours))
+          a1 <- cache.lookupNoUpdate(1)
+          _ <- IO { assert(a1.contains("foo")) }
+          _ <- cache.insert(1, "bar")
+          _ <- IO(ctx.tick(7.hours + 1.second)) // expiration time reached for first timestamp
+          a2 <- cache.lookupNoUpdate(1)
+          _ <- IO { assert(a2.contains("bar")) }
+          _ <- IO(ctx.tick(5.hours)) // expiration time reached for last timestamp
+          a3 <- cache.lookupNoUpdate(1)
+          _ <- IO { assert(a3.isEmpty) }
+        } yield ()
+      )
+      spec.as(1).unsafeRunSync() must_== 1
+    }
+
+  }
+
+  "Auto MemoryCache.ofConcurrentHashMap" should {
+
+    "expire keys" in WithTestContext { ctx => implicit cs => implicit timer =>
+      val spec = Resource.liftF(MemoryCache.ofConcurrentHashMap[IO, Int, String](cacheKeyExpiration.some))
+        .flatMap(cache => MemoryCache.liftToAuto(cache, checkExpirationsEvery).as(cache))
+        .use(cache =>
+          for {
+            _ <- cache.insert(1, "foo")
+            _ <- IO(ctx.tick(5.hours))
+            _ <- cache.insert(2, "bar")
+            a1 <- cache.lookupNoUpdate(1)
+            b1 <- cache.lookupNoUpdate(2)
+            _ <- IO {
+                  assert(a1.contains("foo"))
+                  assert(b1.contains("bar"))
+                }
+            _ <- IO(ctx.tick(7.hours + 1.second)) // expiration time reached
+            a2 <- cache.lookupNoUpdate(1)
+            b2 <- cache.lookupNoUpdate(2)
+            _ <- IO {
+                  assert(a2.isEmpty) // not here
+                  assert(b2.contains("bar"))
+                }
+          } yield ()
+        )
+      spec.as(1).unsafeRunSync() must_== 1
+    }
+
+    "resets expiration" in WithTestContext { ctx => implicit cs => implicit timer =>
+      val spec = Resource.liftF(MemoryCache.ofConcurrentHashMap[IO, Int, String](cacheKeyExpiration.some))
+        .flatMap(cache => MemoryCache.liftToAuto(cache, checkExpirationsEvery).as(cache))
+        .use(cache => 
         for {
           _ <- cache.insert(1, "foo")
           _ <- IO(ctx.tick(5.hours))

--- a/modules/core/src/test/scala/io/chrisdavenport/mules/MemoryCacheSpec.scala
+++ b/modules/core/src/test/scala/io/chrisdavenport/mules/MemoryCacheSpec.scala
@@ -78,6 +78,72 @@ class MemoryCacheSpec extends Specification with CatsIO {
     }
   }
 
+  "MemoryCache.ofShardedImmutableMap" should {
+    "get a value in a quicker period than the timeout" in {
+      val ctx = TestContext()
+      implicit val testTimer: Timer[IO] = ctx.timer[IO]
+      val setup = for {
+        cache <- MemoryCache.ofShardedImmutableMap[IO, String, Int](10, Some(TimeSpec.unsafeFromDuration(1.second)))(Sync[IO], testTimer.clock)
+        _ <- cache.insert("Foo", 1)
+        _ = ctx.tick(1.nano)
+        value <- cache.lookup("Foo")
+      } yield value
+      setup.map(_ must_=== Some(1))
+    }
+
+    "remove a value after delete" in {
+      val ctx = TestContext()
+      implicit val testTimer: Timer[IO] = ctx.timer[IO]
+      val setup = for {
+        cache <- MemoryCache.ofShardedImmutableMap[IO, String, Int](10, Some(TimeSpec.unsafeFromDuration(1.second)))(Sync[IO], testTimer.clock)
+        _ <- cache.insert("Foo", 1)
+        _ <- cache.delete("Foo")
+        value <- cache.lookup("Foo")
+      } yield value
+      setup.map(_ must_=== None)
+    }
+
+    "Remove a value in mass delete" in {
+      val ctx = TestContext()
+      implicit val testTimer: Timer[IO] = ctx.timer[IO]
+      val setup = for {
+        cache <- MemoryCache.ofShardedImmutableMap[IO, String, Int](10, Some(TimeSpec.unsafeFromDuration(1.second)))(Sync[IO], testTimer.clock)
+        _ <- cache.insert("Foo", 1)
+        _ <- Sync[IO].delay(ctx.tick(2.seconds))
+        _ <- cache.purgeExpired
+        value <- cache.lookupNoUpdate("Foo")
+      } yield value
+      setup.map(_ must_=== None)
+    }
+
+    "Lookup after interval fails to get a value" in {
+      val ctx = TestContext()
+      implicit val testTimer: Timer[IO] = ctx.timer[IO]
+      val setup = for {
+        cache <- MemoryCache.ofShardedImmutableMap[IO, String, Int](10, Some(TimeSpec.unsafeFromDuration(1.second)))(Sync[IO], testTimer.clock)
+        _ <- cache.insert("Foo", 1)
+        _ <- Sync[IO].delay(ctx.tick(2.seconds))
+        value <- cache.lookup("Foo")
+      } yield value
+      setup.map(_ must_=== None)
+    }
+
+    "Not Remove an item on lookup No Delete" in {
+      val ctx = TestContext()
+      implicit val testTimer: Timer[IO] = ctx.timer[IO]
+      val setup = for {
+        checkWasTouched <- Ref[IO].of(false)
+        iCache <- MemoryCache.ofShardedImmutableMap[IO, String, Int](10, Some(TimeSpec.unsafeFromDuration(1.second)))(Sync[IO], testTimer.clock)
+        cache = iCache.setOnDelete(_ => checkWasTouched.set(true))
+        _ <- cache.insert("Foo", 1)
+        _ <- Sync[IO].delay(ctx.tick(2.seconds))
+        value <- cache.lookupNoUpdate("Foo")
+        wasTouched <- checkWasTouched.get
+      } yield (value, wasTouched)
+      setup.map(_.must_===((Option.empty[Int], false)))
+    }
+  }
+
   "MemoryCache.ofConcurrentHashMap" should {
     "get a value in a quicker period than the timeout" in {
       val ctx = TestContext()

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "0.3.0-SNAPSHOT"


### PR DESCRIPTION
- Switches to MapRef rather than single implementation
- Requires Exposing Keys and purgeExpiredEntries to allow this to be used based on the different backends.